### PR TITLE
Moved to ci.aquarium instead of using com for java

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -24,7 +24,7 @@ echo
 # Checking only added/modified files since main
 for f in $(git diff --name-only origin/main); do
     # Check text files
-    if file "$f" | grep -q 'text$'; then
+    if file "$f" | grep -q 'text'; then
         # Ends with newline as POSIX requires
         if [ -n "$(tail -c 1 "$f")" ]; then
             echo "ERROR: Should end with newline: $f"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.sparshev.ci.aquarium</groupId>
+    <groupId>ci.aquarium</groupId>
     <artifactId>aquarium-fish-java</artifactId>
     <version>dev-SNAPSHOT</version>
     <packaging>jar</packaging>


### PR DESCRIPTION
Changed the package to ci.aquarium instead of using com prefix. Also fixed checking for text files on linux.

I think it's a good timing because after release we will have issues with compatibility, so it's better to change right away, since Adobe has no intention to continue support of the system.

## Motivation and Context

Organizational

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

